### PR TITLE
Fix webmention replies not counted in social engagement stat

### DIFF
--- a/widget/social-interactions.hbs
+++ b/widget/social-interactions.hbs
@@ -117,9 +117,11 @@
                 });
             }
 
-            // Include webmention in-reply-to counts
+            // Include webmention reply counts (both in-reply-to and mention-of, since
+            // both are displayed together in the "Comments & Replies" section)
             if (wmCategories) {
                 replies += (wmCategories.comments || []).length;
+                replies += (wmCategories.mentions || []).length;
             }
 
             return { likes, reposts, replies };


### PR DESCRIPTION
The calculateTotals function only counted webmentions with wm-property
"in-reply-to" (wmCategories.comments) toward the reply count. However,
renderWebmentionComments displays both comments (in-reply-to) AND mentions
(mention-of, bookmark-of) together in the "Comments & Replies" section.

This caused mention-of webmentions (e.g. blog posts linking to a post) to
appear in the Responses section as replies but show 0 in the stat counter.

Fix by also counting wmCategories.mentions in the reply total.

https://claude.ai/code/session_016KSQTYW3r8aPo5HCokd3CS