### PR TITLE
Harden GitHub Actions workflows against supply-chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Keep SHA-pinned GitHub Actions current. Workflows pin actions to full
+  # commit SHAs (per the supply-chain hardening in
+  # https://nesbitt.io/2026/04/28/github-actions-is-the-weakest-link.html);
+  # Dependabot opens PRs that bump both the SHA and the trailing version
+  # comment so the pins do not silently rot.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,18 @@ on:
       - '**/*.md'
       - 'docs/**'
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        persist-credentials: false
 
     - name: Create secrets directory
       run: mkdir -p secrets

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,13 +10,34 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
+    # Only run when @claude is mentioned AND the actor is a trusted associate of
+    # the repository (OWNER, MEMBER, or COLLABORATOR). This prevents arbitrary
+    # users — including newly created accounts — from triggering the workflow
+    # via issue/PR comments. See nesbitt.io 2026-04-28 (elementary-data incident).
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')
+          && (github.event.comment.author_association == 'OWNER'
+            || github.event.comment.author_association == 'MEMBER'
+            || github.event.comment.author_association == 'COLLABORATOR'))
+        || (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')
+          && (github.event.comment.author_association == 'OWNER'
+            || github.event.comment.author_association == 'MEMBER'
+            || github.event.comment.author_association == 'COLLABORATOR'))
+        || (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')
+          && (github.event.review.author_association == 'OWNER'
+            || github.event.review.author_association == 'MEMBER'
+            || github.event.review.author_association == 'COLLABORATOR'))
+        || (github.event_name == 'issues'
+          && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))
+          && (github.event.issue.author_association == 'OWNER'
+            || github.event.issue.author_association == 'MEMBER'
+            || github.event.issue.author_association == 'COLLABORATOR'))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,13 +47,14 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -47,4 +69,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr:*)'
-

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,40 +1,49 @@
 name: Publish Docker Image
 
+# Trigger directly on pushes to main and tags rather than chaining off the CI
+# workflow via `workflow_run`. The `workflow_run` pattern is a known
+# privilege-laundering footgun: it runs in the context of the default branch
+# but is fired by another workflow's completion, which makes it easy to expand
+# the trust boundary by accident if CI ever starts running on fork PRs with
+# elevated triggers. CI should be enforced as a required status check on `main`
+# via branch protection so that publish only happens for commits that passed CI.
+
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
-    branches: [ main ]
   workflow_dispatch:
   push:
+    branches: [ main ]
     tags:
       - "v*.*.*"
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+
+permissions: {}
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    # Only run this job if CI workflow succeeded or if triggered by a tag push
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@318604b99e75e41977312d83839a89be02ca4893 # v5.9.0
         with:
           images: ${{ secrets.DOCKER_HUB_USERNAME }}/posse
           tags: |
@@ -44,7 +53,7 @@ jobs:
             type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'push' }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
Apply the hardening recommended in
https://nesbitt.io/2026/04/28/github-actions-is-the-weakest-link.html:

- Add empty top-level permissions: {} to all workflows; grant per-job
  contents: read and only the additional scopes Claude needs.
- Pin every third-party action to a 40-char commit SHA with the version
  in a trailing comment; add Dependabot github-actions ecosystem so the
  pins stay current.
- Restrict claude.yml so the @claude trigger only fires for actors with
  OWNER, MEMBER, or COLLABORATOR association — closes the elementary-data
  class of attack where a fresh account can drive an automated workflow.
- Drop docker-publish.yml's workflow_run chain off CI; trigger directly
  on push to main and tag pushes. CI should be enforced as a required
  status check via branch protection instead. Removes the privilege-
  laundering surface that workflow_run exposes.
- Set persist-credentials: false on every checkout so the default token
  is not left on disk after fetch.

Docker Hub auth stays on the existing PAT secret per the user's request;
OIDC migration is out of scope.

https://claude.ai/code/session_019wuBgGpPNV4g3Vmt9fJEtK