### PR TITLE
Sanitize webmention e-content on the server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: help build up down run test test-verbose shell clean install update
+.PHONY: help build up down run test test-verbose shell clean install update resanitize-webmentions resanitize-webmentions-dryrun
+
+STORAGE_PATH ?= ./data
 
 help: ## Show this help message
 	@echo 'Usage: make [target]'
@@ -45,3 +47,9 @@ add: ## Add a new dependency (usage: make add PACKAGE=package-name)
 
 add-dev: ## Add a new dev dependency (usage: make add-dev PACKAGE=package-name)
 	docker compose run --rm app poetry add --group dev $(PACKAGE)
+
+resanitize-webmentions-dryrun: ## Preview re-sanitizing stored webmentions (usage: make resanitize-webmentions-dryrun [STORAGE_PATH=./data])
+	docker compose run --rm app poetry run python -m indieweb.resanitize_stored --storage-path $(STORAGE_PATH) --dry-run --verbose
+
+resanitize-webmentions: ## Re-sanitize stored webmentions in place (usage: make resanitize-webmentions [STORAGE_PATH=./data])
+	docker compose run --rm app poetry run python -m indieweb.resanitize_stored --storage-path $(STORAGE_PATH) --verbose

--- a/src/indieweb/content_sanitizer.py
+++ b/src/indieweb/content_sanitizer.py
@@ -1,0 +1,160 @@
+"""
+Allowlist sanitizer for webmention e-content.
+
+Webmentions arrive with HTML extracted from arbitrary third-party sites.
+The Ghost theme widget sanitizes again before rendering, but storing
+already-cleaned content guards against:
+
+- Stored XSS if the theme is replaced or another consumer reads the
+  /api/webmentions JSON directly.
+- Reliability bugs where mf2py over-extracts content and pulls in
+  JSON-LD, inline CSS, or other non-display markup from <script> /
+  <style> elements, breaking the rendered formatting.
+
+The allowlist (p, br, a, strong, em, blockquote, code, pre) matches the
+widget's ``sanitizeWebmentionHtmlContent`` so server-side and
+client-side filtering stay aligned.
+"""
+
+from html import escape
+from html.parser import HTMLParser
+from urllib.parse import urlparse
+
+_ALLOWED_TAGS = frozenset({"p", "br", "a", "strong", "em", "blockquote", "code", "pre"})
+_VOID_TAGS = frozenset({"br"})
+# Tags whose body content should be discarded entirely, not surfaced as
+# text. mf2py's e-content extraction can scoop up JSON-LD or inline CSS
+# from these, which then leaks into the rendered reply.
+_DROP_CONTENT_TAGS = frozenset({"script", "style"})
+
+
+class _ContentSanitizer(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        self._drop_depth = 0
+
+    def handle_starttag(self, tag: str, attrs: list) -> None:
+        if self._drop_depth:
+            if tag in _DROP_CONTENT_TAGS:
+                self._drop_depth += 1
+            return
+
+        if tag in _DROP_CONTENT_TAGS:
+            self._drop_depth = 1
+            return
+
+        if tag not in _ALLOWED_TAGS:
+            return
+
+        if tag == "a":
+            href = _safe_href(dict(attrs).get("href"))
+            if href:
+                self._parts.append(
+                    f'<a href="{escape(href, quote=True)}" '
+                    f'rel="nofollow noopener noreferrer">'
+                )
+            else:
+                self._parts.append("<a>")
+        else:
+            self._parts.append(f"<{tag}>")
+
+    def handle_startendtag(self, tag: str, attrs: list) -> None:
+        if self._drop_depth:
+            return
+        if tag in _VOID_TAGS:
+            self._parts.append(f"<{tag}>")
+        elif tag in _ALLOWED_TAGS:
+            self.handle_starttag(tag, attrs)
+            self.handle_endtag(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._drop_depth:
+            if tag in _DROP_CONTENT_TAGS:
+                self._drop_depth = max(0, self._drop_depth - 1)
+            return
+        if tag in _ALLOWED_TAGS and tag not in _VOID_TAGS:
+            self._parts.append(f"</{tag}>")
+
+    def handle_data(self, data: str) -> None:
+        if self._drop_depth:
+            return
+        self._parts.append(escape(data, quote=False))
+
+    def result(self) -> str:
+        # If parsing left us inside an unterminated <script>/<style>,
+        # discard nothing further — the input was malformed.
+        return "".join(self._parts)
+
+
+def _safe_href(href) -> str:
+    if not href or not isinstance(href, str):
+        return ""
+    href = href.strip()
+    if not href:
+        return ""
+    try:
+        parsed = urlparse(href)
+    except ValueError:
+        return ""
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return ""
+    return href
+
+
+def sanitize_content_html(html_input: str) -> str:
+    """Return HTML containing only a small allowlist of formatting tags.
+
+    Disallowed tags are dropped but their text content is preserved,
+    except for ``<script>`` and ``<style>`` whose entire body is
+    discarded. All attributes are stripped except ``href`` on ``<a>``,
+    which is restricted to ``http``/``https``.
+    """
+    if not html_input:
+        return ""
+
+    parser = _ContentSanitizer()
+    try:
+        parser.feed(html_input)
+        parser.close()
+    except Exception:
+        return escape(html_input, quote=False)
+    return parser.result()
+
+
+def sanitize_content_text(text_input: str) -> str:
+    """Return plain text with all HTML tags stripped.
+
+    Used for the ``content_text`` field which is supposed to be the
+    plain-text rendering of a reply but may still contain stray markup
+    from over-eager mf2py extraction (e.g. JSON-LD payloads).
+    """
+    if not text_input:
+        return ""
+
+    class _TextOnly(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__(convert_charrefs=True)
+            self._parts: list[str] = []
+            self._drop_depth = 0
+
+        def handle_starttag(self, tag: str, attrs: list) -> None:
+            if tag in _DROP_CONTENT_TAGS:
+                self._drop_depth += 1
+
+        def handle_endtag(self, tag: str) -> None:
+            if tag in _DROP_CONTENT_TAGS and self._drop_depth:
+                self._drop_depth -= 1
+
+        def handle_data(self, data: str) -> None:
+            if self._drop_depth:
+                return
+            self._parts.append(data)
+
+    parser = _TextOnly()
+    try:
+        parser.feed(text_input)
+        parser.close()
+    except Exception:
+        return text_input
+    return "".join(parser._parts)

--- a/src/indieweb/receiver.py
+++ b/src/indieweb/receiver.py
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 
 import mf2py
 
+from indieweb.content_sanitizer import sanitize_content_html, sanitize_content_text
 from indieweb.webmention import (
     _build_session,
     _is_private_or_loopback,
@@ -189,15 +190,19 @@ def _extract_hentry_metadata(
         elif isinstance(author, str):
             result["author_name"] = author
 
-    # Extract content
+    # Extract content. The HTML is sanitized to an allowlist of safe
+    # formatting tags before storage so that consumers of the API don't
+    # have to trust arbitrary remote markup, and so that mf2py's
+    # occasional over-extraction (e.g. JSON-LD from <script>) doesn't
+    # leak into rendered replies.
     content_list = properties.get("content", [])
     if content_list:
         content = content_list[0]
         if isinstance(content, dict):
-            result["content_html"] = content.get("html", "")
-            result["content_text"] = content.get("value", "")
+            result["content_html"] = sanitize_content_html(content.get("html", ""))
+            result["content_text"] = sanitize_content_text(content.get("value", ""))
         elif isinstance(content, str):
-            result["content_text"] = content
+            result["content_text"] = sanitize_content_text(content)
 
     # Determine mention type from properties
     target_normalized = target_url.rstrip("/")

--- a/src/indieweb/resanitize_stored.py
+++ b/src/indieweb/resanitize_stored.py
@@ -1,0 +1,173 @@
+"""
+One-shot maintenance: re-apply the content sanitizer to received
+webmentions already in storage.
+
+Rows persisted before the server-side sanitizer was added still hold
+raw third-party HTML, so JSON-LD payloads, inline CSS, and disallowed
+attributes still come back through ``/api/webmentions``. This walks
+``received_webmentions``, runs the same sanitizers the receiver now
+applies, and rewrites any row whose content changed. The operation is
+idempotent — re-running reports zero changes.
+
+Usage (via the Makefile shortcuts that wrap ``docker compose run``)::
+
+    make resanitize-webmentions-dryrun
+    make resanitize-webmentions
+    make resanitize-webmentions STORAGE_PATH=/app/data/interactions
+
+Or directly inside the container::
+
+    poetry run python -m indieweb.resanitize_stored --storage-path ./data --dry-run
+    poetry run python -m indieweb.resanitize_stored --storage-path ./data
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sqlite3
+import sys
+from typing import Iterator, Optional, Tuple
+
+from indieweb.content_sanitizer import sanitize_content_html, sanitize_content_text
+
+
+def _iter_rows(conn: sqlite3.Connection) -> Iterator[Tuple[int, str, str]]:
+    cursor = conn.execute(
+        "SELECT rowid, content_html, content_text FROM received_webmentions"
+    )
+    for row in cursor:
+        yield row[0], row[1] or "", row[2] or ""
+
+
+def resanitize_storage(
+    storage_path: str,
+    *,
+    dry_run: bool = False,
+    on_change=None,
+) -> dict:
+    """Re-sanitize all stored received-webmention content.
+
+    Args:
+        storage_path: Directory containing ``interactions.db``.
+        dry_run: When True, do not write any updates.
+        on_change: Optional callback invoked as ``on_change(rowid, before, after)``
+            for each row whose sanitized form differs from its stored form.
+            ``before`` and ``after`` are ``(html, text)`` tuples.
+
+    Returns:
+        Summary dict with ``rows_scanned``, ``rows_changed``, and per-field
+        byte deltas.
+    """
+    db_path = os.path.join(storage_path, "interactions.db")
+    if not os.path.isfile(db_path):
+        raise FileNotFoundError(f"Database not found: {db_path}")
+
+    summary = {
+        "rows_scanned": 0,
+        "rows_changed": 0,
+        "html_bytes_before": 0,
+        "html_bytes_after": 0,
+        "text_bytes_before": 0,
+        "text_bytes_after": 0,
+    }
+
+    conn = sqlite3.connect(db_path)
+    try:
+        changes: list[Tuple[int, str, str]] = []
+        for rowid, html_in, text_in in _iter_rows(conn):
+            summary["rows_scanned"] += 1
+            html_out = sanitize_content_html(html_in)
+            text_out = sanitize_content_text(text_in)
+
+            if html_out == html_in and text_out == text_in:
+                continue
+
+            summary["rows_changed"] += 1
+            summary["html_bytes_before"] += len(html_in)
+            summary["html_bytes_after"] += len(html_out)
+            summary["text_bytes_before"] += len(text_in)
+            summary["text_bytes_after"] += len(text_out)
+            changes.append((rowid, html_out, text_out))
+
+            if on_change is not None:
+                on_change(rowid, (html_in, text_in), (html_out, text_out))
+
+        if not dry_run and changes:
+            with conn:
+                conn.executemany(
+                    "UPDATE received_webmentions "
+                    "SET content_html = ?, content_text = ? "
+                    "WHERE rowid = ?",
+                    [(html, text, rowid) for rowid, html, text in changes],
+                )
+    finally:
+        conn.close()
+
+    return summary
+
+
+def _print_change(rowid: int, before, after) -> None:
+    html_before, text_before = before
+    html_after, text_after = after
+    print(
+        f"  row {rowid}: "
+        f"html {len(html_before)} -> {len(html_after)} bytes, "
+        f"text {len(text_before)} -> {len(text_after)} bytes"
+    )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Re-sanitize content_html and content_text on all stored "
+            "received webmentions."
+        ),
+    )
+    parser.add_argument(
+        "--storage-path",
+        default="./data",
+        help="Directory containing interactions.db (default: ./data)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report what would change without writing anything.",
+    )
+    parser.add_argument(
+        "--verbose",
+        "-v",
+        action="store_true",
+        help="Print every row that changes.",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        summary = resanitize_storage(
+            storage_path=args.storage_path,
+            dry_run=args.dry_run,
+            on_change=_print_change if args.verbose else None,
+        )
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    mode = "dry-run" if args.dry_run else "applied"
+    print(
+        f"[{mode}] scanned {summary['rows_scanned']} row(s), "
+        f"{summary['rows_changed']} changed"
+    )
+    if summary["rows_changed"]:
+        print(
+            f"  content_html: {summary['html_bytes_before']} "
+            f"-> {summary['html_bytes_after']} bytes"
+        )
+        print(
+            f"  content_text: {summary['text_bytes_before']} "
+            f"-> {summary['text_bytes_after']} bytes"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_content_sanitizer.py
+++ b/tests/test_content_sanitizer.py
@@ -1,0 +1,173 @@
+"""Tests for the webmention e-content sanitizer."""
+
+from indieweb.content_sanitizer import (
+    sanitize_content_html,
+    sanitize_content_text,
+)
+
+
+class TestSanitizeContentHtml:
+    def test_empty(self):
+        assert sanitize_content_html("") == ""
+        assert sanitize_content_html(None) == ""  # type: ignore[arg-type]
+
+    def test_allowlisted_tags_preserved(self):
+        html = "<p>Hello <strong>world</strong></p>"
+        assert sanitize_content_html(html) == "<p>Hello <strong>world</strong></p>"
+
+    def test_all_allowed_tags(self):
+        html = (
+            "<p>p <br>br <strong>s</strong> <em>e</em> "
+            "<blockquote>bq</blockquote> <code>c</code> <pre>pr</pre></p>"
+        )
+        out = sanitize_content_html(html)
+        for tag in ("<p>", "<br>", "<strong>", "<em>", "<blockquote>", "<code>", "<pre>"):
+            assert tag in out
+
+    def test_disallowed_tag_kept_as_text(self):
+        html = "<p>Hello <span>nested</span> world</p>"
+        assert sanitize_content_html(html) == "<p>Hello nested world</p>"
+
+    def test_nested_div_dropped_but_inner_preserved(self):
+        html = "<div><p>hi</p></div>"
+        assert sanitize_content_html(html) == "<p>hi</p>"
+
+    def test_script_content_dropped_entirely(self):
+        """The bug that motivated this: JSON-LD inside <script> must not
+        leak through as visible text."""
+        html = (
+            '<p>Real reply.</p>'
+            '<script type="application/ld+json">'
+            '{"@context":"https://schema.org","@type":"Person","name":"x"}'
+            '</script>'
+        )
+        out = sanitize_content_html(html)
+        assert out == "<p>Real reply.</p>"
+        assert "schema.org" not in out
+        assert "@context" not in out
+
+    def test_style_content_dropped_entirely(self):
+        html = "<style>.x{color:red}</style><p>hi</p>"
+        assert sanitize_content_html(html) == "<p>hi</p>"
+
+    def test_nested_script_in_disallowed_tag(self):
+        html = "<div>before<script>bad()</script>after</div>"
+        assert sanitize_content_html(html) == "beforeafter"
+
+    def test_attributes_stripped(self):
+        html = '<p class="x" id="y" onclick="alert(1)">hi</p>'
+        assert sanitize_content_html(html) == "<p>hi</p>"
+
+    def test_anchor_http_href_preserved(self):
+        html = '<a href="https://example.com/post">link</a>'
+        out = sanitize_content_html(html)
+        assert 'href="https://example.com/post"' in out
+        assert 'rel="nofollow noopener noreferrer"' in out
+
+    def test_anchor_http_scheme_allowed(self):
+        html = '<a href="http://example.com">link</a>'
+        out = sanitize_content_html(html)
+        assert 'href="http://example.com"' in out
+
+    def test_anchor_javascript_href_dropped(self):
+        html = '<a href="javascript:alert(1)">click</a>'
+        out = sanitize_content_html(html)
+        assert "javascript" not in out
+        assert "<a>click</a>" == out
+
+    def test_anchor_data_href_dropped(self):
+        html = '<a href="data:text/html,<script>alert(1)</script>">x</a>'
+        out = sanitize_content_html(html)
+        assert "data:" not in out
+        assert "<script>" not in out
+        assert "alert" not in out
+
+    def test_anchor_vbscript_dropped(self):
+        html = '<a href="vbscript:msgbox(1)">x</a>'
+        out = sanitize_content_html(html)
+        assert "vbscript" not in out
+
+    def test_anchor_relative_url_dropped(self):
+        # No netloc → can't trust origin → drop
+        html = '<a href="/relative/path">x</a>'
+        out = sanitize_content_html(html)
+        assert "relative" not in out
+        assert out == "<a>x</a>"
+
+    def test_anchor_href_quote_escaped(self):
+        html = '<a href=\'https://example.com/"><script>alert(1)</script>\'>x</a>'
+        out = sanitize_content_html(html)
+        assert "<script>" not in out
+        assert "&quot;" in out or '"' not in out.replace('href="', "").replace('">', "")
+
+    def test_iframe_dropped(self):
+        html = '<iframe src="https://evil.com"></iframe><p>hi</p>'
+        assert sanitize_content_html(html) == "<p>hi</p>"
+
+    def test_img_dropped(self):
+        html = '<img src="x" onerror="alert(1)"><p>hi</p>'
+        assert sanitize_content_html(html) == "<p>hi</p>"
+
+    def test_text_html_entities_escaped(self):
+        html = "<p>5 < 6 and a&b</p>"
+        out = sanitize_content_html(html)
+        assert "<p>" in out
+        assert "&lt;" in out
+        assert "&amp;" in out
+        assert "</p>" in out
+
+    def test_existing_entity_preserved_as_escaped(self):
+        html = "<p>&amp;lt;</p>"
+        # convert_charrefs decodes the entity to "<lt;" then re-escapes
+        # the literal < as &lt;, which is still safe.
+        out = sanitize_content_html(html)
+        assert "<p>" in out and "</p>" in out
+        assert "<lt" not in out  # the literal "<" must be escaped
+
+    def test_html_comments_dropped(self):
+        html = "<p>hi<!-- secret --></p>"
+        out = sanitize_content_html(html)
+        assert "secret" not in out
+        assert out == "<p>hi</p>"
+
+    def test_malformed_input_doesnt_crash(self):
+        html = "<p>unclosed <strong>still <em>open"
+        out = sanitize_content_html(html)
+        assert "unclosed" in out
+        assert "<script>" not in out
+
+    def test_svg_with_inner_script_dropped(self):
+        html = '<svg><script>alert(1)</script></svg><p>ok</p>'
+        out = sanitize_content_html(html)
+        assert "alert" not in out
+        assert "<p>ok</p>" in out
+
+    def test_self_closing_br(self):
+        html = "<p>line1<br/>line2</p>"
+        out = sanitize_content_html(html)
+        assert "<br>" in out
+        assert "line1" in out and "line2" in out
+
+
+class TestSanitizeContentText:
+    def test_empty(self):
+        assert sanitize_content_text("") == ""
+        assert sanitize_content_text(None) == ""  # type: ignore[arg-type]
+
+    def test_plain_text_passthrough(self):
+        assert sanitize_content_text("hello world") == "hello world"
+
+    def test_tags_stripped(self):
+        assert sanitize_content_text("<p>hello</p>") == "hello"
+
+    def test_script_body_dropped(self):
+        text = '<script type="application/ld+json">{"foo":1}</script>real text'
+        assert sanitize_content_text(text) == "real text"
+
+    def test_style_body_dropped(self):
+        text = "<style>.x{color:red}</style>real text"
+        assert sanitize_content_text(text) == "real text"
+
+    def test_entities_decoded(self):
+        # convert_charrefs=True decodes named entities to text
+        assert sanitize_content_text("a &amp; b") == "a & b"

--- a/tests/test_resanitize_stored.py
+++ b/tests/test_resanitize_stored.py
@@ -1,0 +1,161 @@
+"""Tests for the stored-webmention re-sanitization tool."""
+
+import os
+import sqlite3
+
+import pytest
+
+from indieweb.resanitize_stored import main, resanitize_storage
+from interactions.storage import InteractionDataStore
+
+
+@pytest.fixture
+def populated_store(tmp_path):
+    """A store with a mix of clean and dirty stored webmentions."""
+    store = InteractionDataStore(str(tmp_path))
+
+    rows = [
+        # 0: dirty — JSON-LD inside <script> should be dropped from both fields
+        (
+            "https://a.example/post",
+            "https://blog.example.com/p1",
+            "<p>Real reply.</p>"
+            '<script type="application/ld+json">{"@context":"x"}</script>',
+            '<script type="application/ld+json">{"@context":"x"}</script>Real reply.',
+        ),
+        # 1: dirty — disallowed attrs and tags
+        (
+            "https://b.example/post",
+            "https://blog.example.com/p2",
+            '<p class="x" onclick="alert(1)">hi <span>there</span></p>',
+            "hi there",
+        ),
+        # 2: clean — already sanitized
+        (
+            "https://c.example/post",
+            "https://blog.example.com/p3",
+            "<p>already clean</p>",
+            "already clean",
+        ),
+        # 3: NULL content (some early rows may have NULLs)
+        (
+            "https://d.example/post",
+            "https://blog.example.com/p4",
+            None,
+            None,
+        ),
+    ]
+
+    with sqlite3.connect(store.db_path) as conn:
+        conn.executemany(
+            "INSERT INTO received_webmentions "
+            "(source, target, content_html, content_text, received_at, status) "
+            "VALUES (?, ?, ?, ?, '2026-01-01T00:00:00+00:00', 'verified')",
+            rows,
+        )
+
+    return str(tmp_path)
+
+
+def _fetch_all(storage_path):
+    db = os.path.join(storage_path, "interactions.db")
+    with sqlite3.connect(db) as conn:
+        return conn.execute(
+            "SELECT source, content_html, content_text "
+            "FROM received_webmentions ORDER BY source"
+        ).fetchall()
+
+
+class TestResanitizeStorage:
+    def test_dry_run_does_not_write(self, populated_store):
+        before = _fetch_all(populated_store)
+        summary = resanitize_storage(populated_store, dry_run=True)
+        after = _fetch_all(populated_store)
+
+        assert before == after
+        assert summary["rows_scanned"] == 4
+        assert summary["rows_changed"] == 2
+
+    def test_applies_changes(self, populated_store):
+        summary = resanitize_storage(populated_store, dry_run=False)
+        assert summary["rows_changed"] == 2
+
+        rows = {source: (html, text) for source, html, text in _fetch_all(populated_store)}
+
+        # Row 0: script body dropped from html, JSON-LD stripped from text
+        assert rows["https://a.example/post"][0] == "<p>Real reply.</p>"
+        assert "@context" not in rows["https://a.example/post"][0]
+        assert "@context" not in (rows["https://a.example/post"][1] or "")
+
+        # Row 1: disallowed attrs/tags stripped
+        assert rows["https://b.example/post"][0] == "<p>hi there</p>"
+
+        # Row 2: untouched
+        assert rows["https://c.example/post"][0] == "<p>already clean</p>"
+
+        # Row 3: NULLs left as-is (sanitizers map empty -> empty, no change)
+        assert rows["https://d.example/post"] == (None, None)
+
+    def test_is_idempotent(self, populated_store):
+        first = resanitize_storage(populated_store, dry_run=False)
+        second = resanitize_storage(populated_store, dry_run=False)
+
+        assert first["rows_changed"] == 2
+        assert second["rows_changed"] == 0
+
+    def test_on_change_callback(self, populated_store):
+        observed = []
+
+        def cb(rowid, before, after):
+            observed.append((rowid, before, after))
+
+        resanitize_storage(populated_store, dry_run=True, on_change=cb)
+        assert len(observed) == 2
+        # before != after for every reported change
+        for _, before, after in observed:
+            assert before != after
+
+    def test_missing_db_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            resanitize_storage(str(tmp_path / "nope"))
+
+    def test_empty_table(self, tmp_path):
+        InteractionDataStore(str(tmp_path))  # creates empty DB
+        summary = resanitize_storage(str(tmp_path), dry_run=False)
+        assert summary == {
+            "rows_scanned": 0,
+            "rows_changed": 0,
+            "html_bytes_before": 0,
+            "html_bytes_after": 0,
+            "text_bytes_before": 0,
+            "text_bytes_after": 0,
+        }
+
+
+class TestCli:
+    def test_dry_run_exit_zero(self, populated_store, capsys):
+        rc = main(["--storage-path", populated_store, "--dry-run"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "[dry-run]" in out
+        assert "2 changed" in out
+
+    def test_apply_exit_zero(self, populated_store, capsys):
+        rc = main(["--storage-path", populated_store])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "[applied]" in out
+        assert "2 changed" in out
+
+    def test_verbose_lists_rows(self, populated_store, capsys):
+        rc = main(["--storage-path", populated_store, "--dry-run", "--verbose"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Two changed rows should be reported individually
+        assert out.count("row ") >= 2
+
+    def test_missing_db_exit_one(self, tmp_path, capsys):
+        rc = main(["--storage-path", str(tmp_path / "nope")])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "error" in err.lower()


### PR DESCRIPTION
Strips received webmention content to an allowlist of formatting tags
(p, br, a, strong, em, blockquote, code, pre) before storage, mirroring
the Ghost theme widget's client-side filter. The body of <script> and
<style> tags is dropped entirely so JSON-LD and inline CSS that mf2py
pulls into the e-content extraction no longer leaks through as visible
text in rendered replies.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>