### PR TITLE
Append ?ref=<platform> to syndicated URLs for Ghost analytics

### DIFF
--- a/src/posse/posse.py
+++ b/src/posse/posse.py
@@ -38,7 +38,7 @@ from html.parser import HTMLParser
 from logging.handlers import RotatingFileHandler
 from typing import List, TYPE_CHECKING, Dict, Optional, Any
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 from pathlib import Path
 
 if TYPE_CHECKING:
@@ -284,29 +284,61 @@ def _filter_nosplit_tag(tags: List[Dict[str, str]]) -> List[Dict[str, str]]:
     return [tag for tag in tags if tag.get("name", "").lower() != NOSPLIT_TAG]
 
 
-def _format_post_content(post_title: str, post_url: str, excerpt: Optional[str], tags: List[Dict[str, str]], max_length: int) -> str:
+def _add_ref_to_url(url: str, ref: str) -> str:
+    """Append a ref query parameter to a URL for analytics attribution.
+
+    If the URL already has a ref parameter, it is preserved unchanged.
+
+    Args:
+        url: URL to annotate
+        ref: Value for the ref query parameter (e.g. "mastodon", "bluesky")
+
+    Returns:
+        URL with ?ref=<ref> appended (or original URL if ref is already set)
+    """
+    if not url or not ref:
+        return url
+
+    try:
+        parsed = urlparse(url)
+        query_params = parse_qsl(parsed.query, keep_blank_values=True)
+        if any(k == "ref" for k, _ in query_params):
+            return url
+        query_params.append(("ref", ref))
+        return urlunparse(parsed._replace(query=urlencode(query_params)))
+    except Exception as e:
+        logger.warning(f"Failed to add ref={ref} to URL {url}: {e}")
+        return url
+
+
+def _format_post_content(post_title: str, post_url: str, excerpt: Optional[str], tags: List[Dict[str, str]], max_length: int, ref: Optional[str] = None) -> str:
     """Format post content for a specific platform with character limit.
-    
+
     Args:
         post_title: Title of the post
         post_url: URL of the post
         excerpt: Optional excerpt text
         tags: List of tag dictionaries with 'name' and 'slug' fields
         max_length: Maximum character length for the post content
-        
+        ref: Optional value for a ?ref= query parameter appended to the post URL,
+             so Ghost analytics can attribute referrals to a specific platform.
+
     Returns:
         Formatted post content string
     """
+    if ref:
+        post_url = _add_ref_to_url(post_url, ref)
+
     # Extract hashtags from post tags, excluding #nosplit, #dont-duplicate-feature, and append #posse
     hashtag_list = [x['name'].lower() for x in tags if "#" in x["name"] and (x['name'].lower() != NOSPLIT_TAG and x["name"].lower() != NOFEATURE_TAG)]
     hashtag_list.append("#posse")
     hashtags = " ".join(hashtag_list)
-    
+
     # Calculate space needed for tags and URL (with newlines for spacing)
     # Single newline after content, double newline before URL for visual separation
     fixed_content = f"\n{hashtags}\n\n🔗 {post_url}"
     max_text_length = max_length - len(fixed_content)
-    
+
     text_content = trim_to_words(excerpt or post_title, max_text_length)
     return f"{text_content}{fixed_content}"
 
@@ -552,8 +584,13 @@ def process_events(mastodon_clients: List["MastodonClient"] = None, bluesky_clie
                         - image_url: URL of the image for this split
                 """
                 try:
-                    # Format content with platform-specific character limit
-                    content = _format_post_content(title, url, excerpt, tags, client.max_post_length)
+                    # Format content with platform-specific character limit.
+                    # Pass the platform name as ?ref= so Ghost analytics can
+                    # attribute traffic back to the syndication source.
+                    content = _format_post_content(
+                        title, url, excerpt, tags, client.max_post_length,
+                        ref=platform.lower(),
+                    )
 
                     logger.info(f"Posting to {platform} account '{client.account_name}'...")
                     result = client.post(

--- a/tests/test_ref_links.py
+++ b/tests/test_ref_links.py
@@ -1,0 +1,102 @@
+"""Tests for ?ref= query parameter on syndicated post URLs.
+
+Ghost analytics uses the `ref` query parameter to attribute incoming
+traffic to a referrer. POSSE appends `?ref=<platform>` to the post URL
+in the syndicated content so Ghost can distinguish visits coming from
+Mastodon vs Bluesky vs other sources.
+"""
+import unittest
+
+from posse.posse import _add_ref_to_url, _format_post_content
+
+
+class TestAddRefToUrl(unittest.TestCase):
+    """Tests for _add_ref_to_url helper."""
+
+    def test_appends_ref_to_plain_url(self):
+        result = _add_ref_to_url("https://example.com/post", "mastodon")
+        self.assertEqual(result, "https://example.com/post?ref=mastodon")
+
+    def test_appends_ref_when_existing_query_present(self):
+        result = _add_ref_to_url("https://example.com/post?utm_source=foo", "bluesky")
+        self.assertEqual(result, "https://example.com/post?utm_source=foo&ref=bluesky")
+
+    def test_preserves_existing_ref(self):
+        url = "https://example.com/post?ref=newsletter"
+        result = _add_ref_to_url(url, "mastodon")
+        self.assertEqual(result, url)
+
+    def test_preserves_fragment(self):
+        result = _add_ref_to_url("https://example.com/post#section", "mastodon")
+        self.assertEqual(result, "https://example.com/post?ref=mastodon#section")
+
+    def test_empty_url_returns_unchanged(self):
+        self.assertEqual(_add_ref_to_url("", "mastodon"), "")
+
+    def test_empty_ref_returns_unchanged(self):
+        url = "https://example.com/post"
+        self.assertEqual(_add_ref_to_url(url, ""), url)
+
+
+class TestFormatPostContentRef(unittest.TestCase):
+    """Tests for ref parameter in _format_post_content."""
+
+    def test_ref_appended_to_post_url(self):
+        content = _format_post_content(
+            post_title="Test",
+            post_url="https://example.com/post",
+            excerpt="An excerpt",
+            tags=[],
+            max_length=500,
+            ref="mastodon",
+        )
+        self.assertIn("https://example.com/post?ref=mastodon", content)
+
+    def test_no_ref_leaves_url_unchanged(self):
+        content = _format_post_content(
+            post_title="Test",
+            post_url="https://example.com/post",
+            excerpt="An excerpt",
+            tags=[],
+            max_length=500,
+        )
+        self.assertIn("https://example.com/post", content)
+        self.assertNotIn("ref=", content)
+
+    def test_different_platforms_get_different_refs(self):
+        mastodon_content = _format_post_content(
+            post_title="Test",
+            post_url="https://example.com/post",
+            excerpt="An excerpt",
+            tags=[],
+            max_length=500,
+            ref="mastodon",
+        )
+        bluesky_content = _format_post_content(
+            post_title="Test",
+            post_url="https://example.com/post",
+            excerpt="An excerpt",
+            tags=[],
+            max_length=500,
+            ref="bluesky",
+        )
+        self.assertIn("?ref=mastodon", mastodon_content)
+        self.assertIn("?ref=bluesky", bluesky_content)
+
+    def test_ref_counts_against_max_length(self):
+        # Long excerpt should be trimmed to fit ref= addition
+        long_excerpt = "x" * 1000
+        content = _format_post_content(
+            post_title="Test",
+            post_url="https://example.com/post",
+            excerpt=long_excerpt,
+            tags=[],
+            max_length=200,
+            ref="mastodon",
+        )
+        self.assertLessEqual(len(content), 200)
+        self.assertIn("?ref=mastodon", content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Ghost analytics attributes referrals by the `ref` query parameter on
incoming URLs. Without it, traffic from Mastodon and Bluesky shows up
as direct visits, hiding where readers actually came from. Each
syndicated post URL now carries `?ref=mastodon` or `?ref=bluesky`
(preserving any existing query string or pre-set ref).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>