### PR TITLE
Fix correctness, concurrency, and SSRF issues from full-tree review

### DIFF
--- a/src/indieweb/receiver.py
+++ b/src/indieweb/receiver.py
@@ -12,16 +12,17 @@ References:
 """
 
 import logging
-import re
 from datetime import datetime, timezone
-from typing import Any, Dict, Optional
-from urllib.parse import urlparse
+from html.parser import HTMLParser
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import parse_qsl, urljoin, urlparse
 
 import mf2py
 
 from indieweb.content_sanitizer import sanitize_content_html, sanitize_content_text
 from indieweb.webmention import (
     _build_session,
+    _checked_get,
     _is_private_or_loopback,
     _read_bounded_response,
     MAX_DISCOVERY_RESPONSE_BYTES,
@@ -61,11 +62,14 @@ def verify_webmention(source_url: str, target_url: str, store: Any, timeout: flo
 
     session = _build_session()
     try:
-        response = session.get(
+        # _checked_get re-validates every redirect hop against the SSRF guard, so
+        # an attacker-controlled redirect can't steer the fetch to an internal
+        # address after the initial source_url passed the check above.
+        response = _checked_get(
+            session,
             source_url,
             headers={"Accept": "text/html"},
             timeout=timeout,
-            allow_redirects=True,
             stream=True,
         )
     except Exception as e:
@@ -102,7 +106,7 @@ def verify_webmention(source_url: str, target_url: str, store: Any, timeout: flo
         html_body = body.decode("utf-8", errors="replace")
 
     # Verify source actually links to target
-    if not _source_links_to_target(html_body, target_url):
+    if not _source_links_to_target(html_body, target_url, base_url=source_url):
         logger.info(f"Source does not link to target: source={source_url}, target={target_url}")
         store.update_webmention_verification(
             source=source_url, target=target_url, status="rejected",
@@ -133,19 +137,65 @@ def verify_webmention(source_url: str, target_url: str, store: Any, timeout: flo
     return {"status": "verified", **metadata}
 
 
-def _source_links_to_target(html_body: str, target_url: str) -> bool:
-    """Check if the HTML body contains a link to the target URL."""
-    # Normalize target for comparison (strip trailing slash)
-    target_normalized = target_url.rstrip("/")
+class _LinkHrefExtractor(HTMLParser):
+    """Collect href values from real <a>/<link> elements.
 
-    # Check for exact URL match or match without trailing slash in href attributes
-    # This covers <a href="...">, <link href="...">, etc.
-    escaped_target = re.escape(target_url)
-    escaped_normalized = re.escape(target_normalized)
+    Using an HTML parser (rather than a regex over the raw markup) means hrefs
+    that appear only inside comments, <script>, or <template> blocks are not
+    treated as links to the target — those don't constitute a visible mention.
+    """
 
-    # Match href="target" or href='target' (with or without trailing slash)
-    pattern = rf'''href=["'](?:{escaped_target}|{escaped_normalized}/?)["']'''
-    return bool(re.search(pattern, html_body, re.IGNORECASE))
+    def __init__(self) -> None:
+        super().__init__()
+        self.hrefs: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        if tag in ("a", "link"):
+            for name, value in attrs:
+                if name == "href" and value:
+                    self.hrefs.append(value)
+
+
+def _normalize_for_link_match(url: str) -> Optional[Tuple[str, str, tuple]]:
+    """Normalize a URL into a comparison key, or None if it can't be parsed.
+
+    Ignores differences that shouldn't defeat verification: the scheme
+    (http vs https), a trailing slash, the fragment, and a ``ref`` query
+    parameter (POSSE appends ``?ref=<platform>`` to its own syndicated links).
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return None
+    netloc = parsed.netloc.lower()
+    if not netloc:
+        return None
+    path = parsed.path.rstrip("/") or "/"
+    query = tuple(sorted(
+        (k, v) for k, v in parse_qsl(parsed.query, keep_blank_values=True) if k != "ref"
+    ))
+    return (netloc, path, query)
+
+
+def _source_links_to_target(html_body: str, target_url: str, base_url: str = "") -> bool:
+    """Check whether the HTML body contains a visible link to the target URL."""
+    target_key = _normalize_for_link_match(target_url)
+    if target_key is None:
+        return False
+
+    parser = _LinkHrefExtractor()
+    try:
+        parser.feed(html_body)
+    except Exception as e:
+        logger.debug(f"HTML parse failed while verifying link to target: {e}")
+        return False
+
+    for href in parser.hrefs:
+        # Resolve relative hrefs against the source page when we know its URL.
+        resolved = urljoin(base_url, href) if base_url else href
+        if _normalize_for_link_match(resolved) == target_key:
+            return True
+    return False
 
 
 def _extract_hentry_metadata(

--- a/src/indieweb/webmention.py
+++ b/src/indieweb/webmention.py
@@ -92,6 +92,45 @@ def _build_session() -> requests.Session:
     return session
 
 
+class BlockedAddressError(requests.exceptions.RequestException):
+    """A request target (or one of its redirect hops) resolved to a blocked address."""
+
+
+def _checked_get(session: requests.Session, url: str, **kwargs) -> requests.Response:
+    """GET ``url`` while validating every hop against the SSRF guard.
+
+    requests' own redirect following only happens after a connection is made, so
+    letting it auto-follow would let an attacker-controlled ``Location`` send us
+    to an internal address even though the initial URL passed the guard. Instead
+    we follow redirects manually, re-running ``_is_private_or_loopback`` on each
+    hop *before* connecting to it.
+
+    Returns the final (non-redirect) response. Raises:
+        BlockedAddressError: a hop resolved to a private/loopback address.
+        requests.exceptions.TooManyRedirects: the chain exceeded MAX_REDIRECTS.
+        requests.exceptions.RequestException: any underlying transport error.
+    """
+    kwargs.pop("allow_redirects", None)
+    current_url = url
+    for _ in range(MAX_REDIRECTS + 1):
+        if _is_private_or_loopback(current_url):
+            raise BlockedAddressError(
+                f"Blocked request to private/loopback address: {current_url}"
+            )
+        response = session.get(current_url, allow_redirects=False, **kwargs)
+        if response.is_redirect:
+            location = response.headers.get("Location")
+            response.close()
+            if not location:
+                return response
+            current_url = urljoin(current_url, location)
+            continue
+        return response
+    raise requests.exceptions.TooManyRedirects(
+        f"Exceeded {MAX_REDIRECTS} redirects fetching {url}"
+    )
+
+
 @dataclass
 class WebmentionResult:
     """Result of a webmention send attempt.
@@ -250,6 +289,9 @@ class WebmentionClient:
                 headers={"Content-Type": "application/x-www-form-urlencoded"},
                 timeout=target.timeout,
                 stream=True,
+                # Endpoint already passed the SSRF guard; don't auto-follow a
+                # redirect to an unvalidated (possibly internal) address.
+                allow_redirects=False,
             )
 
             # Read bounded response body to prevent memory exhaustion
@@ -334,11 +376,11 @@ def discover_webmention_endpoint(target_url: str, timeout: float = 30.0) -> Opti
 
     session = _build_session()
     try:
-        response = session.get(
+        response = _checked_get(
+            session,
             target_url,
             headers={"Accept": "text/html"},
             timeout=timeout,
-            allow_redirects=True,
             stream=True,
         )
         response.raise_for_status()
@@ -461,6 +503,9 @@ def send_webmention(source_url: str, target_url: str, timeout: float = 30.0) -> 
             headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=timeout,
             stream=True,
+            # Endpoint already passed the SSRF guard; don't auto-follow a
+            # redirect to an unvalidated (possibly internal) address.
+            allow_redirects=False,
         )
 
         # Read bounded response body to prevent memory exhaustion

--- a/src/interactions/interaction_sync.py
+++ b/src/interactions/interaction_sync.py
@@ -144,6 +144,17 @@ class InteractionSyncService:
         # new replies after the sync completes.
         previous_reply_urls = self._collect_reply_urls(existing_data.get("platforms", {}))
 
+        # Capture which accounts already had interaction data. An account with no
+        # prior entry (first discovery, or a resurrection after dead-link
+        # suppression wiped its reply history) is seeded silently rather than
+        # notifying for every pre-existing reply as if it were brand new.
+        previously_present_accounts = {
+            (platform_name, account_name)
+            for platform_name, accounts in existing_data.get("platforms", {}).items()
+            if isinstance(accounts, dict)
+            for account_name in accounts
+        }
+
         # Check if we have existing data to preserve
         has_existing_mastodon = bool(existing_data.get("platforms", {}).get("mastodon", {}))
         has_existing_bluesky = bool(existing_data.get("platforms", {}).get("bluesky", {}))
@@ -281,12 +292,27 @@ class InteractionSyncService:
         except Exception as e:
             logger.error(f"Unexpected error during Bluesky interaction sync: {e}", exc_info=True)
 
-        # Notify about new replies before storing updated data
-        if self.notifier:
-            self._notify_new_replies(previous_reply_urls, interactions)
+        # Persist atomically with respect to the dead-link sweep and webhook-time
+        # syndication writes. This sync may have spent minutes on network calls
+        # against a snapshot taken at the top; before writing it back, re-read the
+        # mapping and drop any account the sweep confirmed deleted in the
+        # meantime, so a mid-sync suppression isn't resurrected by this write.
+        with self.data_store.transaction():
+            fresh_mapping = self._load_syndication_mapping(ghost_post_id) or {}
+            fresh_platforms = fresh_mapping.get("platforms", {})
+            for platform_name in ("mastodon", "bluesky"):
+                for acct, acct_data in fresh_platforms.get(platform_name, {}).items():
+                    if self._is_account_deleted(acct_data):
+                        self._drop_account(interactions, platform_name, acct)
 
-        # Store the interaction data
-        self._store_interaction_data(ghost_post_id, interactions)
+            # Notify about new replies before storing updated data
+            if self.notifier:
+                self._notify_new_replies(
+                    previous_reply_urls, interactions, previously_present_accounts
+                )
+
+            # Store the interaction data
+            self._store_interaction_data(ghost_post_id, interactions)
 
         # Log appropriate message based on sync results
         total_to_sync = mastodon_accounts_to_sync + bluesky_accounts_to_sync
@@ -338,22 +364,10 @@ class InteractionSyncService:
             return None
 
         try:
-            # Get the status
+            # Get the status. Favourite/reblog/reply totals come straight off the
+            # status object (favourites_count / reblogs_count / replies_count), so
+            # there is no need to page status_favourited_by / status_reblogged_by.
             status = client.api.status(status_id)
-
-            # Get favourites (with pagination for accounts) - limit to avoid timeouts
-            try:
-                favourited_by = client.api.status_favourited_by(status_id)
-            except (Timeout, RequestException, TypeError) as e:
-                logger.warning(f"Error fetching favourites for status {status_id}: {e}")
-                favourited_by = []
-
-            # Get reblogs (with pagination for accounts) - limit to avoid timeouts
-            try:
-                reblogged_by = client.api.status_reblogged_by(status_id)
-            except (Timeout, RequestException, TypeError) as e:
-                logger.warning(f"Error fetching reblogs for status {status_id}: {e}")
-                reblogged_by = []
 
             # Get context (replies)
             try:
@@ -362,24 +376,29 @@ class InteractionSyncService:
                 logger.warning(f"Timeout fetching context for status {status_id}: {e}")
                 context = {}
 
-            # Extract reply previews (limit to 10 most recent)
+            # Extract reply previews. Filter to direct replies first, THEN take the
+            # 10 most recent — slicing the raw descendants (which includes nested
+            # reply-to-reply chatter, oldest-first) would drop direct replies past
+            # the first 10 descendants and keep the oldest rather than the newest.
+            direct_replies = [
+                reply for reply in context.get("descendants", [])
+                if reply.get("in_reply_to_id") == status_id
+            ]
             reply_previews = []
-            for reply in context.get("descendants", [])[:10]:
-                # Only include direct replies, not replies to replies
-                if reply.get("in_reply_to_id") == status_id:
-                    # Convert datetime to ISO format string if needed
-                    created_at = reply.get("created_at", "")
-                    if hasattr(created_at, 'isoformat'):
-                        created_at = created_at.isoformat()
+            for reply in direct_replies[-10:]:
+                # Convert datetime to ISO format string if needed
+                created_at = reply.get("created_at", "")
+                if hasattr(created_at, 'isoformat'):
+                    created_at = created_at.isoformat()
 
-                    reply_previews.append({
-                        "author": f"@{reply['account']['acct']}",
-                        "author_url": reply['account']['url'],
-                        "author_avatar": reply['account']['avatar'],
-                        "content": self._strip_html(reply.get("content", "")),
-                        "created_at": created_at,
-                        "url": reply.get("url", "")
-                    })
+                reply_previews.append({
+                    "author": f"@{reply['account']['acct']}",
+                    "author_url": reply['account']['url'],
+                    "author_avatar": reply['account']['avatar'],
+                    "content": self._strip_html(reply.get("content", "")),
+                    "created_at": created_at,
+                    "url": reply.get("url", "")
+                })
 
             return {
                 "status_id": status_id,
@@ -515,21 +534,13 @@ class InteractionSyncService:
         # Try to sync, with one retry if token is expired
         for attempt in range(2):
             try:
-                # Get post thread (includes the post and replies)
+                # Get post thread (includes the post, its like/repost/reply totals,
+                # and the reply previews). The thread post view already carries
+                # like_count / repost_count / reply_count, so there's no need for
+                # separate get_likes / get_reposted_by calls (which also capped the
+                # totals at their page limit of 100).
                 thread_response = client.api.app.bsky.feed.get_post_thread({"uri": post_uri})
                 thread = thread_response.thread
-
-                # Get likes
-                likes_response = client.api.app.bsky.feed.get_likes({
-                    "uri": post_uri,
-                    "limit": 100
-                })
-
-                # Get reposts
-                reposts_response = client.api.app.bsky.feed.get_reposted_by({
-                    "uri": post_uri,
-                    "limit": 100
-                })
 
                 # Extract reply previews from thread
                 reply_previews = []
@@ -547,16 +558,13 @@ class InteractionSyncService:
                                 "url": f"https://bsky.app/profile/{author.handle}/post/{post.uri.split('/')[-1]}"
                             })
 
-                # Count interactions
-                like_count = len(likes_response.likes) if hasattr(likes_response, 'likes') else 0
-                repost_count = len(reposts_response.reposted_by) if hasattr(reposts_response, 'reposted_by') else 0
-
-                # Get reply count from thread post
-                reply_count = 0
-                if hasattr(thread, 'post') and hasattr(thread.post, 'reply_count'):
-                    reply_count = thread.post.reply_count
-                elif hasattr(thread, 'replies'):
-                    reply_count = len(thread.replies)
+                # Read interaction totals from the thread post view.
+                thread_post = thread.post if hasattr(thread, 'post') else None
+                like_count = getattr(thread_post, 'like_count', 0) or 0
+                repost_count = getattr(thread_post, 'repost_count', 0) or 0
+                reply_count = getattr(thread_post, 'reply_count', None)
+                if reply_count is None:
+                    reply_count = len(thread.replies) if hasattr(thread, 'replies') else 0
 
                 return {
                     "post_uri": post_uri,
@@ -695,18 +703,31 @@ class InteractionSyncService:
         self,
         previous_reply_urls: set,
         new_data: Dict[str, Any],
+        previously_present_accounts: Optional[set] = None,
     ) -> None:
         """Send notifications for replies that were not present in the previous sync.
 
         Args:
             previous_reply_urls: Set of reply URLs already known before this sync
             new_data: Freshly synced interaction data
+            previously_present_accounts: Set of (platform, account) tuples that
+                already had interaction data before this sync. Accounts absent
+                from this set are being populated for the first time (or after a
+                dead-link suppression wiped their history) and are seeded silently
+                instead of notifying for every pre-existing reply. When None, all
+                accounts are eligible (legacy behavior).
         """
         for platform_name, accounts in new_data.get("platforms", {}).items():
             if not isinstance(accounts, dict):
                 continue
             for account_name, account_data in accounts.items():
                 if not isinstance(account_data, dict):
+                    continue
+                if (
+                    previously_present_accounts is not None
+                    and (platform_name, account_name) not in previously_present_accounts
+                ):
+                    # No prior data for this account — seed without notifying.
                     continue
                 for reply in account_data.get("reply_previews", []):
                     url = reply.get("url")
@@ -881,71 +902,13 @@ class InteractionSyncService:
 
             # Phase 2 — re-read the mapping fresh and apply the decisions by status_id.
             # Only in-memory work happens here (no network), so the read-modify-write
-            # window is tiny and concurrent syndication writes survive.
-            fresh = self.data_store.get_syndication_mapping(ghost_post_id)
-            if not fresh:
-                continue
-            fresh_accounts = fresh.get("platforms", {}).get("mastodon", {})
-            mapping_changed = False
-
-            for account_name, status_results in results.items():
-                account_data = fresh_accounts.get(account_name)
-                if account_data is None:
-                    continue  # account concurrently removed / re-syndicated
-                was_deleted = self._is_account_deleted(account_data)
-                entries = account_data if isinstance(account_data, list) else [account_data]
-                account_changed = False
-
-                for entry in entries:
-                    if not isinstance(entry, dict):
-                        continue
-                    sid = str(entry.get("status_id") or "")
-                    if sid not in status_results:
-                        continue
-
-                    if status_results[sid]:
-                        # Resurrect: clear any accumulated dead state.
-                        dead_keys = ("deleted", "dead_strikes", "first_seen_dead", "last_dead_check")
-                        if any(k in entry for k in dead_keys):
-                            for k in dead_keys:
-                                entry.pop(k, None)
-                            account_changed = True
-                        continue
-
-                    # Confirmed 404 — record a strike and the check time (drives backoff).
-                    strikes = int(entry.get("dead_strikes", 0)) + 1
-                    entry["dead_strikes"] = strikes
-                    entry.setdefault("first_seen_dead", self._now_isoformat())
-                    entry["last_dead_check"] = self._now_isoformat()
-                    account_changed = True
-                    if strikes >= self.dead_link_confirm_threshold:
-                        entry["deleted"] = True
-                    else:
-                        stats["pending_strikes"] += 1
-
-                if account_changed:
-                    mapping_changed = True
-
-                now_deleted = self._is_account_deleted(account_data)
-                if now_deleted and not was_deleted:
-                    self._suppress_account_in_interaction_data(ghost_post_id, account_name)
-                    stats["newly_suppressed"] += 1
-                    logger.warning(
-                        f"Suppressed dead Mastodon link for post {ghost_post_id} "
-                        f"account '{account_name}' (confirmed 404)"
-                    )
-                elif was_deleted and not now_deleted:
-                    self._restore_account_in_interaction_data(
-                        ghost_post_id, account_name, account_data
-                    )
-                    stats["resurrected"] += 1
-                    logger.info(
-                        f"Restored Mastodon link for post {ghost_post_id} "
-                        f"account '{account_name}' (status reachable again)"
-                    )
-
-            if mapping_changed:
-                self.data_store.put_syndication_mapping(ghost_post_id, fresh)
+            # window is tiny. The lock serializes it against concurrent syndication
+            # writes (store_syndication_mapping) so neither clobbers the other.
+            with self.data_store.transaction():
+                fresh = self.data_store.get_syndication_mapping(ghost_post_id)
+                if not fresh:
+                    continue
+                self._apply_dead_link_decisions(ghost_post_id, fresh, results, stats)
 
         logger.info(
             f"Dead-link sweep complete: checked={stats['checked']}, "
@@ -954,6 +917,82 @@ class InteractionSyncService:
             f"pending_strikes={stats['pending_strikes']}"
         )
         return stats
+
+    def _apply_dead_link_decisions(
+        self,
+        ghost_post_id: str,
+        fresh: Dict[str, Any],
+        results: Dict[str, Dict[str, bool]],
+        stats: Dict[str, int],
+    ) -> None:
+        """Apply existence-check results to a freshly-read mapping and persist.
+
+        Caller must hold ``data_store.transaction()``. Mutates ``fresh`` in place,
+        flags/clears dead state per status, suppresses or restores interaction
+        data as accounts cross the deleted threshold, and writes the mapping back
+        if anything changed.
+        """
+        fresh_accounts = fresh.get("platforms", {}).get("mastodon", {})
+        mapping_changed = False
+
+        for account_name, status_results in results.items():
+            account_data = fresh_accounts.get(account_name)
+            if account_data is None:
+                continue  # account concurrently removed / re-syndicated
+            was_deleted = self._is_account_deleted(account_data)
+            entries = account_data if isinstance(account_data, list) else [account_data]
+            account_changed = False
+
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                sid = str(entry.get("status_id") or "")
+                if sid not in status_results:
+                    continue
+
+                if status_results[sid]:
+                    # Resurrect: clear any accumulated dead state.
+                    dead_keys = ("deleted", "dead_strikes", "first_seen_dead", "last_dead_check")
+                    if any(k in entry for k in dead_keys):
+                        for k in dead_keys:
+                            entry.pop(k, None)
+                        account_changed = True
+                    continue
+
+                # Confirmed 404 — record a strike and the check time (drives backoff).
+                strikes = int(entry.get("dead_strikes", 0)) + 1
+                entry["dead_strikes"] = strikes
+                entry.setdefault("first_seen_dead", self._now_isoformat())
+                entry["last_dead_check"] = self._now_isoformat()
+                account_changed = True
+                if strikes >= self.dead_link_confirm_threshold:
+                    entry["deleted"] = True
+                else:
+                    stats["pending_strikes"] += 1
+
+            if account_changed:
+                mapping_changed = True
+
+            now_deleted = self._is_account_deleted(account_data)
+            if now_deleted and not was_deleted:
+                self._suppress_account_in_interaction_data(ghost_post_id, account_name)
+                stats["newly_suppressed"] += 1
+                logger.warning(
+                    f"Suppressed dead Mastodon link for post {ghost_post_id} "
+                    f"account '{account_name}' (confirmed 404)"
+                )
+            elif was_deleted and not now_deleted:
+                self._restore_account_in_interaction_data(
+                    ghost_post_id, account_name, account_data
+                )
+                stats["resurrected"] += 1
+                logger.info(
+                    f"Restored Mastodon link for post {ghost_post_id} "
+                    f"account '{account_name}' (status reachable again)"
+                )
+
+        if mapping_changed:
+            self.data_store.put_syndication_mapping(ghost_post_id, fresh)
 
     def _within_recheck_backoff(self, entry: Dict[str, Any]) -> bool:
         """Return True if a confirmed-dead entry was rechecked too recently to retry.
@@ -976,17 +1015,18 @@ class InteractionSyncService:
 
     def _suppress_account_in_interaction_data(self, ghost_post_id: str, account_name: str) -> None:
         """Remove a Mastodon account from stored interaction data so the widget hides it."""
-        data = self.data_store.get(ghost_post_id)
-        if not data:
-            return
-        before = (
-            account_name in data.get("syndication_links", {}).get("mastodon", {})
-            or account_name in data.get("platforms", {}).get("mastodon", {})
-        )
-        self._drop_account(data, "mastodon", account_name)
-        if before:
-            data["updated_at"] = self._now_isoformat()
-            self.data_store.put(ghost_post_id, data)
+        with self.data_store.transaction():
+            data = self.data_store.get(ghost_post_id)
+            if not data:
+                return
+            before = (
+                account_name in data.get("syndication_links", {}).get("mastodon", {})
+                or account_name in data.get("platforms", {}).get("mastodon", {})
+            )
+            self._drop_account(data, "mastodon", account_name)
+            if before:
+                data["updated_at"] = self._now_isoformat()
+                self.data_store.put(ghost_post_id, data)
 
     def _restore_account_in_interaction_data(
         self, ghost_post_id: str, account_name: str, account_data: Any
@@ -999,11 +1039,12 @@ class InteractionSyncService:
         post_url = self._featured_post_url(account_data)
         if not post_url:
             return
-        data = self.data_store.get(ghost_post_id) or self._empty_interaction_data(ghost_post_id)
-        links = data.setdefault("syndication_links", {"mastodon": {}, "bluesky": {}})
-        links.setdefault("mastodon", {})[account_name] = {"post_url": post_url}
-        data["updated_at"] = self._now_isoformat()
-        self.data_store.put(ghost_post_id, data)
+        with self.data_store.transaction():
+            data = self.data_store.get(ghost_post_id) or self._empty_interaction_data(ghost_post_id)
+            links = data.setdefault("syndication_links", {"mastodon": {}, "bluesky": {}})
+            links.setdefault("mastodon", {})[account_name] = {"post_url": post_url}
+            data["updated_at"] = self._now_isoformat()
+            self.data_store.put(ghost_post_id, data)
 
     def _load_syndication_mapping(self, ghost_post_id: str) -> Optional[Dict[str, Any]]:
         """
@@ -1368,27 +1409,30 @@ def update_interaction_data_on_syndication(
     tz_name = InteractionSyncService._normalize_timezone_name(timezone_name)
     now = datetime.now(ZoneInfo(tz_name)).isoformat()
 
-    existing = data_store.get(ghost_post_id)
-    if existing is None:
-        existing = {
-            "ghost_post_id": ghost_post_id,
-            "updated_at": now,
-            "syndication_links": {"mastodon": {}, "bluesky": {}},
-            "platforms": {"mastodon": {}, "bluesky": {}},
-        }
+    # Guard the read-modify-write against concurrent interaction-data writers
+    # (periodic sync, dead-link sweep) so this syndication link isn't lost.
+    with data_store.transaction():
+        existing = data_store.get(ghost_post_id)
+        if existing is None:
+            existing = {
+                "ghost_post_id": ghost_post_id,
+                "updated_at": now,
+                "syndication_links": {"mastodon": {}, "bluesky": {}},
+                "platforms": {"mastodon": {}, "bluesky": {}},
+            }
 
-    existing["updated_at"] = now
+        existing["updated_at"] = now
 
-    # Ensure structure is intact after loading (defensive, in case of partial data)
-    if not isinstance(existing.get("syndication_links"), dict):
-        existing["syndication_links"] = {"mastodon": {}, "bluesky": {}}
-    for p in ("mastodon", "bluesky"):
-        if p not in existing["syndication_links"]:
-            existing["syndication_links"][p] = {}
+        # Ensure structure is intact after loading (defensive, in case of partial data)
+        if not isinstance(existing.get("syndication_links"), dict):
+            existing["syndication_links"] = {"mastodon": {}, "bluesky": {}}
+        for p in ("mastodon", "bluesky"):
+            if p not in existing["syndication_links"]:
+                existing["syndication_links"][p] = {}
 
-    existing["syndication_links"][platform][account_name] = {"post_url": post_url}
+        existing["syndication_links"][platform][account_name] = {"post_url": post_url}
 
-    data_store.put(ghost_post_id, existing)
+        data_store.put(ghost_post_id, existing)
     logger.info(
         f"Updated interaction_data syndication_links for {ghost_post_id} "
         f"{platform}/{account_name}: {post_url}"
@@ -1452,6 +1496,35 @@ def store_syndication_mapping(
     """
     data_store = InteractionDataStore(storage_path)
 
+    # Serialize the whole read-modify-write so parallel posts to different
+    # accounts (each running store_syndication_mapping from its own thread-pool
+    # worker) don't read the same row and overwrite each other's entries.
+    with data_store.transaction():
+        _store_syndication_mapping_locked(
+            data_store,
+            ghost_post_id=ghost_post_id,
+            ghost_post_url=ghost_post_url,
+            platform=platform,
+            account_name=account_name,
+            post_data=post_data,
+            storage_path=storage_path,
+            split_info=split_info,
+            timezone_name=timezone_name,
+        )
+
+
+def _store_syndication_mapping_locked(
+    data_store: "InteractionDataStore",
+    ghost_post_id: str,
+    ghost_post_url: str,
+    platform: str,
+    account_name: str,
+    post_data: Dict[str, Any],
+    storage_path: str,
+    split_info: Optional[Dict[str, Any]],
+    timezone_name: str,
+) -> None:
+    """Read-modify-write body of store_syndication_mapping. Caller holds the lock."""
     # Load existing mapping from SQLite
     mapping = data_store.get_syndication_mapping(ghost_post_id)
 

--- a/src/interactions/scheduler.py
+++ b/src/interactions/scheduler.py
@@ -72,6 +72,9 @@ class InteractionScheduler:
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._sweep_thread: Optional[threading.Thread] = None
+        # Monotonic count of completed sync cycles, used to throttle older posts
+        # to every Nth cycle regardless of wall-clock hour or sync interval.
+        self._sync_cycle = 0
         # Cache for Ghost posts to reduce API calls
         self._ghost_posts_cache: Dict[str, Dict[str, Any]] = {}
         self._ghost_posts_cache_time: Optional[datetime] = None
@@ -183,6 +186,11 @@ class InteractionScheduler:
         if not mappings:
             logger.debug("No syndication mappings found")
             return
+
+        # Advance the cycle counter so age-based throttling syncs older posts every
+        # Nth cycle. (Counting cycles rather than wall-clock hour parity avoids
+        # starving posts when the sync interval keeps every cycle on the same hour.)
+        self._sync_cycle += 1
 
         logger.info(f"Found {len(mappings)} posts with syndication mappings")
 
@@ -313,8 +321,10 @@ class InteractionScheduler:
         - Posts 2-7 days old: sync every 2nd cycle (moderate engagement)
         - Posts 7-30 days old: sync every 4th cycle (low engagement)
 
-        Uses a deterministic approach based on current time to ensure
-        posts eventually get synced even if scheduler restarts.
+        Throttling is based on a monotonic per-run cycle counter so older posts
+        are reliably synced every Nth cycle. (An earlier version keyed off the
+        wall-clock hour, which starved older posts whenever the configured sync
+        interval kept every cycle landing on the same-parity hour.)
 
         Args:
             post_age_days: Age of post in days
@@ -327,12 +337,10 @@ class InteractionScheduler:
             return True
         elif post_age_days < 7:
             # Sync every 2nd cycle for posts 2-7 days old
-            # Use hour of day to determine if we should sync
-            return self._now().hour % 2 == 0
+            return self._sync_cycle % 2 == 0
         else:
             # Sync every 4th cycle for posts 7-30 days old
-            # Use hour of day to determine if we should sync
-            return self._now().hour % 4 == 0
+            return self._sync_cycle % 4 == 0
 
     def trigger_manual_sync(self, ghost_post_id: str) -> None:
         """

--- a/src/interactions/storage.py
+++ b/src/interactions/storage.py
@@ -6,12 +6,34 @@ import json
 import logging
 import os
 import sqlite3
+import threading
 from typing import Any, Dict, Optional
 
 from jsonschema import ValidationError, validate
 from schema import INTERACTION_DATA_PAYLOAD_SCHEMA, SYNDICATION_MAPPING_PAYLOAD_SCHEMA
 
 logger = logging.getLogger(__name__)
+
+
+# Read-modify-write sequences on a row (load payload, mutate it, write it back)
+# are not atomic across SQLite connections, and several threads touch the same
+# rows concurrently: the event-processor thread pool (store_syndication_mapping),
+# the scheduler sync thread, and the dead-link sweep thread. A per-database
+# reentrant lock serializes those sequences within the process so concurrent
+# writers don't clobber each other. Keyed by absolute db path so every store
+# instance pointed at the same file shares one lock.
+_db_locks: Dict[str, threading.RLock] = {}
+_db_locks_guard = threading.Lock()
+
+
+def _get_db_lock(db_path: str) -> threading.RLock:
+    key = os.path.abspath(db_path)
+    with _db_locks_guard:
+        lock = _db_locks.get(key)
+        if lock is None:
+            lock = threading.RLock()
+            _db_locks[key] = lock
+        return lock
 
 
 def _normalize_interaction_payload(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -53,7 +75,24 @@ class InteractionDataStore:
         self.storage_path = storage_path
         os.makedirs(self.storage_path, mode=0o755, exist_ok=True)
         self.db_path = os.path.join(self.storage_path, "interactions.db")
+        self._lock = _get_db_lock(self.db_path)
         self._ensure_schema()
+
+    def transaction(self) -> threading.RLock:
+        """Return the per-database lock for guarding read-modify-write sequences.
+
+        Use as a context manager around a load/mutate/store sequence so it runs
+        atomically with respect to other threads writing the same row::
+
+            with store.transaction():
+                data = store.get(post_id)
+                data["x"] = ...
+                store.put(post_id, data)
+
+        The lock is reentrant, so nested ``with store.transaction()`` blocks on
+        the same thread are safe.
+        """
+        return self._lock
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.db_path)

--- a/src/notifications/pushover.py
+++ b/src/notifications/pushover.py
@@ -34,6 +34,7 @@ Security:
 """
 import os
 import logging
+import threading
 import time
 from typing import Optional, Dict, Any
 import requests
@@ -515,6 +516,12 @@ class PushoverLoggingHandler(logging.Handler):
         self.notifier = notifier
         self.rate_limit_seconds = rate_limit_seconds
         self._last_notification_time: float = 0.0
+        # Re-entrancy guard. Sending a notification can itself log at ERROR (e.g.
+        # the Pushover API is unreachable), which routes back into this handler.
+        # Without a guard that recurses until the stack overflows, since the
+        # rate-limit timestamp is only advanced on success. Per-thread so a
+        # failing emit on one thread can't suppress legitimate emits on another.
+        self._local = threading.local()
         # Default to ERROR level
         self.setLevel(logging.ERROR)
 
@@ -532,11 +539,17 @@ class PushoverLoggingHandler(logging.Handler):
         if not self.notifier.enabled:
             return
 
+        # Skip if we're already inside an emit on this thread: notifying can log
+        # at ERROR, which would re-enter here and recurse until the stack blows.
+        if getattr(self._local, "emitting", False):
+            return
+
         # Apply rate limiting
         current_time = time.time()
         if current_time - self._last_notification_time < self.rate_limit_seconds:
             return
 
+        self._local.emitting = True
         try:
             # Format the log message
             message = self.format(record)
@@ -554,3 +567,5 @@ class PushoverLoggingHandler(logging.Handler):
         except Exception:
             # Don't let notification failures break logging
             self.handleError(record)
+        finally:
+            self._local.emitting = False

--- a/src/posse/posse.py
+++ b/src/posse/posse.py
@@ -33,11 +33,10 @@ Example:
 from queue import Queue
 import threading
 import logging
-import re
 from html.parser import HTMLParser
 from logging.handlers import RotatingFileHandler
 from typing import List, TYPE_CHECKING, Dict, Optional, Any
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import ThreadPoolExecutor, as_completed, TimeoutError as FuturesTimeoutError
 from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 from pathlib import Path
 
@@ -91,12 +90,20 @@ def trim_to_words(text: str, max_length: int) -> str:
     Returns:
         Trimmed text with ellipsis if needed
     """
+    # No room for any text (e.g. hashtags + URL already fill the platform limit).
+    if max_length <= 0:
+        return ""
+
     if len(text) <= max_length:
         return text
-    
+
+    # Too little room even for an ellipsis: hard-cut to the available width.
+    if max_length <= 3:
+        return text[:max_length]
+
     # Reserve 3 characters for ellipsis
     max_length -= 3
-    
+
     # Find the last space before max_length
     trimmed = text[:max_length]
     last_space = trimmed.rfind(' ')
@@ -272,18 +279,6 @@ def _has_nosplit_tag(tags: List[Dict[str, str]]) -> bool:
     return False
 
 
-def _filter_nosplit_tag(tags: List[Dict[str, str]]) -> List[Dict[str, str]]:
-    """Filter out the nosplit tag from the post tags.
-
-    Args:
-        tags: List of tag dictionaries with 'name' and 'slug' fields
-
-    Returns:
-        Filtered list of tags without the nosplit tag
-    """
-    return [tag for tag in tags if tag.get("name", "").lower() != NOSPLIT_TAG]
-
-
 def _add_ref_to_url(url: str, ref: str) -> str:
     """Append a ref query parameter to a URL for analytics attribution.
 
@@ -337,29 +332,12 @@ def _format_post_content(post_title: str, post_url: str, excerpt: Optional[str],
     # Calculate space needed for tags and URL (with newlines for spacing)
     # Single newline after content, double newline before URL for visual separation
     fixed_content = f"\n{hashtags}\n\n🔗 {post_url}"
-    max_text_length = max_length - len(fixed_content)
+    # Clamp so a long hashtag set + URL can't drive this negative, which would
+    # make trim_to_words slice with a negative index and return over-length text.
+    max_text_length = max(0, max_length - len(fixed_content))
 
     text_content = trim_to_words(excerpt or post_title, max_text_length)
     return f"{text_content}{fixed_content}"
-
-
-def _prepare_content(post: Dict[str, Any], max_length: int) -> tuple[str, List[str], List[str], List[Dict[str, str]]]:
-    """Prepare content for posting from Ghost post data.
-    
-    Args:
-        post: Ghost post data dictionary
-        max_length: Maximum character length for the post content
-        
-    Returns:
-        Tuple of (post_content, images, media_descriptions, tags)
-    """
-    # Extract raw data
-    post_title, post_url, excerpt, images, media_descriptions, tags = _extract_post_data(post)
-    
-    # Format content with character limit
-    post_content = _format_post_content(post_title, post_url, excerpt, tags, max_length)
-    
-    return post_content, images, media_descriptions, tags
 
 
 def _generate_missing_alt_text(images: List[str], media_descriptions: List[str], llm_client) -> List[str]:
@@ -729,14 +707,25 @@ def process_events(mastodon_clients: List["MastodonClient"] = None, bluesky_clie
                 
                 # Wait for all posts to complete. Allow enough time for the
                 # built-in transient-error retries in each client (per-attempt
-                # API timeouts plus exponential backoff).
+                # API timeouts plus exponential backoff). A slow account that
+                # exceeds the wait budget must NOT abort the rest of this post's
+                # processing (image cleanup, webmention sending, task_done), so
+                # the as_completed timeout is caught and we proceed with whatever
+                # results are ready. The executor's __exit__ still waits for the
+                # straggler to finish in the background.
                 results = []
-                for future in as_completed(futures, timeout=120):
-                    try:
-                        result = future.result()
-                        results.append(result)
-                    except Exception as e:
-                        logger.error(f"Future execution failed: {e}", exc_info=True)
+                try:
+                    for future in as_completed(futures, timeout=120):
+                        try:
+                            result = future.result()
+                            results.append(result)
+                        except Exception as e:
+                            logger.error(f"Future execution failed: {e}", exc_info=True)
+                except FuturesTimeoutError:
+                    logger.error(
+                        f"Timed out after 120s waiting for {len(futures)} posting task(s) "
+                        f"to complete; proceeding with {len(results)} result(s) ready so far"
+                    )
                 
                 # Log summary
                 success_count = sum(1 for r in results if r.get("success"))

--- a/src/social/bluesky_client.py
+++ b/src/social/bluesky_client.py
@@ -142,8 +142,12 @@ class BlueskyClient(SocialMediaClient):
             split_multi_image_posts=split_multi_image_posts
         )
     
-    # HTTP status codes worth retrying: 5xx server errors and 429 rate limits.
-    _TRANSIENT_STATUS_CODES = frozenset({500, 502, 503, 504, 429})
+    # HTTP status codes worth retrying. Deliberately excludes 500/502/504: a
+    # bare 500 or a gateway 502/504 can be emitted *after* the upstream PDS has
+    # already committed the record, so retrying a non-idempotent send_post on
+    # those risks a duplicate post. 429 (rate limited) and 503 (service
+    # unavailable) are explicit "I did not process this request" signals.
+    _TRANSIENT_STATUS_CODES = frozenset({429, 503})
 
     @classmethod
     def _is_transient_error(cls, exception: Exception) -> bool:
@@ -156,8 +160,10 @@ class BlueskyClient(SocialMediaClient):
 
         - NetworkError: the request never got a response (connection refused,
           reset, DNS, etc.).
-        - RequestException with a 5xx/429 status: the server explicitly rejected
-          the request without committing it.
+        - RequestException with a 429 or 503 status: the server explicitly
+          refused to process the request (rate limited / unavailable). Ambiguous
+          5xx codes (500/502/504) are NOT retried — they can be returned after a
+          commit, which is exactly when a retry would duplicate the post.
 
         InvokeTimeoutError (a subclass of NetworkError) is deliberately excluded:
         a read timeout is ambiguous — the write may have succeeded server-side —
@@ -221,8 +227,17 @@ class BlueskyClient(SocialMediaClient):
         # Post-process URLs to remove common trailing punctuation
         processed_urls = []
         for url, start, end in urls:
-            # Remove trailing punctuation that's likely not part of the URL
-            while url and url[-1] in '.,;!?)':
+            # Remove trailing punctuation that's likely not part of the URL. A
+            # closing ')' is only stripped when it has no matching '(' inside the
+            # URL, so links that legitimately end in ')' — e.g. Wikipedia's
+            # ".../Python_(programming_language)" — keep their final paren.
+            while url:
+                last = url[-1]
+                if last == ')':
+                    if url.count('(') >= url.count(')'):
+                        break
+                elif last not in '.,;!?':
+                    break
                 url = url[:-1]
                 end -= 1
             if url:  # Only add if URL is not empty after stripping
@@ -239,6 +254,13 @@ class BlueskyClient(SocialMediaClient):
         # Build the rich text by processing content in order
         last_pos = 0
         for match_type, match_text, start, end in all_matches:
+            # Skip matches that overlap an already-emitted facet. This drops, for
+            # example, a "#fragment" that the hashtag regex finds *inside* a URL
+            # that was already emitted as a link — without it the fragment text
+            # would be duplicated and last_pos rewound, corrupting byte offsets.
+            if start < last_pos:
+                continue
+
             # Add any plain text before this match
             if start > last_pos:
                 text_builder.text(content[last_pos:start])

--- a/tests/test_bluesky.py
+++ b/tests/test_bluesky.py
@@ -967,6 +967,49 @@ class TestBlueskyClient(unittest.TestCase):
         self.assertIsNotNone(result)
 
     @patch("social.bluesky_client.Client")
+    def test_url_with_balanced_parens_keeps_closing_paren(self, mock_client_class):
+        """A URL that legitimately ends in ')' must not have the paren stripped."""
+        mock_client_class.return_value = MagicMock()
+        client = BlueskyClient(
+            instance_url="https://bsky.social",
+            handle="user.bsky.social",
+            app_password="test_password",
+        )
+
+        content = "See https://en.wikipedia.org/wiki/Python_(programming_language) now"
+        builder = client._build_rich_text(content)
+
+        # Text is preserved verbatim, and the single link facet covers the whole
+        # URL including its balanced trailing ')'.
+        self.assertEqual(builder.build_text(), content)
+        facets = builder.build_facets()
+        self.assertEqual(len(facets), 1)
+        link_text = content.encode("UTF-8")[
+            facets[0].index.byte_start:facets[0].index.byte_end
+        ].decode("UTF-8")
+        self.assertEqual(link_text, "https://en.wikipedia.org/wiki/Python_(programming_language)")
+
+    @patch("social.bluesky_client.Client")
+    def test_url_with_fragment_does_not_duplicate_as_hashtag(self, mock_client_class):
+        """A '#fragment' inside a URL must not be re-emitted as a hashtag facet."""
+        mock_client_class.return_value = MagicMock()
+        client = BlueskyClient(
+            instance_url="https://bsky.social",
+            handle="user.bsky.social",
+            app_password="test_password",
+        )
+
+        content = "see https://example.com/page#intro for details"
+        builder = client._build_rich_text(content)
+
+        # The fragment is part of the URL: text is not corrupted/duplicated and
+        # only the URL facet exists (no stray hashtag facet for '#intro').
+        self.assertEqual(builder.build_text(), content)
+        facets = builder.build_facets()
+        self.assertEqual(len(facets), 1)
+        self.assertIsInstance(facets[0].features[0], models.AppBskyRichtextFacet.Link)
+
+    @patch("social.bluesky_client.Client")
     def test_post_re_authenticates_before_posting(self, mock_client_class):
         """Test that post() re-authenticates before each post to avoid ExpiredToken errors."""
         # Setup mock API

--- a/tests/test_post_retry.py
+++ b/tests/test_post_retry.py
@@ -173,11 +173,18 @@ class TestMastodonRetry(unittest.TestCase):
 class TestBlueskyTransientDetection(unittest.TestCase):
     """Bluesky transient-error classifier (structured atproto exceptions)."""
 
-    def test_500_status_detected(self):
-        self.assertTrue(BlueskyClient._is_transient_error(_request_exception(500)))
+    def test_500_status_not_retried(self):
+        # A bare 500 can be returned after the record was committed; retrying a
+        # non-idempotent send_post would risk a duplicate post.
+        self.assertFalse(BlueskyClient._is_transient_error(_request_exception(500)))
 
-    def test_502_status_detected(self):
-        self.assertTrue(BlueskyClient._is_transient_error(_request_exception(502)))
+    def test_502_status_not_retried(self):
+        # Gateway 502 — upstream commit state unknown, so do not retry.
+        self.assertFalse(BlueskyClient._is_transient_error(_request_exception(502)))
+
+    def test_504_status_not_retried(self):
+        # Gateway timeout — the write may have committed; do not retry.
+        self.assertFalse(BlueskyClient._is_transient_error(_request_exception(504)))
 
     def test_503_status_detected(self):
         self.assertTrue(BlueskyClient._is_transient_error(_request_exception(503)))

--- a/tests/test_pushover.py
+++ b/tests/test_pushover.py
@@ -28,12 +28,56 @@ Running Tests:
     $ pytest tests/test_pushover.py -v
     $ pytest tests/test_pushover.py --cov=notifications
 """
+import logging
 import os
 import pytest
 from unittest.mock import patch, MagicMock
 import requests
 
-from notifications.pushover import PushoverNotifier
+from notifications.pushover import PushoverNotifier, PushoverLoggingHandler
+
+
+class TestPushoverLoggingHandler:
+    """Test suite for the logging handler that forwards ERROR logs to Pushover."""
+
+    def test_emit_does_not_recurse_when_send_logs_error(self):
+        """A send failure that itself logs at ERROR must not re-enter emit().
+
+        The notifier's _send_notification logs an error on failure; that log
+        record routes back through this handler. Without the re-entrancy guard
+        this recurses until the stack overflows, since the rate-limit timestamp
+        only advances on success.
+        """
+        notifier = MagicMock()
+        notifier.enabled = True
+
+        handler = PushoverLoggingHandler(notifier, rate_limit_seconds=0)
+
+        # Simulate notify_log_error failing by logging an ERROR through the same
+        # handler (as the real _send_notification does on RequestException).
+        call_count = {"n": 0}
+
+        def failing_notify(**kwargs):
+            call_count["n"] += 1
+            # Re-enter emit exactly as a logged error would.
+            record = logging.LogRecord(
+                name="notifications.pushover", level=logging.ERROR,
+                pathname=__file__, lineno=1,
+                msg="Failed to send Pushover notification", args=(), exc_info=None,
+            )
+            handler.emit(record)
+            return False
+
+        notifier.notify_log_error.side_effect = failing_notify
+
+        trigger = logging.LogRecord(
+            name="some.module", level=logging.ERROR,
+            pathname=__file__, lineno=1, msg="boom", args=(), exc_info=None,
+        )
+        # Must return without RecursionError; the re-entrant emit is suppressed,
+        # so notify_log_error is invoked exactly once.
+        handler.emit(trigger)
+        assert call_count["n"] == 1
 
 
 class TestPushoverNotifier:

--- a/tests/test_ref_links.py
+++ b/tests/test_ref_links.py
@@ -97,6 +97,23 @@ class TestFormatPostContentRef(unittest.TestCase):
         self.assertLessEqual(len(content), 200)
         self.assertIn("?ref=mastodon", content)
 
+    def test_long_hashtags_do_not_corrupt_content(self):
+        # When tags + URL alone exceed the limit, the available text width goes
+        # negative. The clamp must yield empty body text rather than slicing with
+        # a negative index (which previously returned most of the over-length
+        # excerpt). The URL must still be present and intact.
+        tags = [{"name": "#" + "a" * 60, "slug": "a"}, {"name": "#" + "b" * 60, "slug": "b"}]
+        content = _format_post_content(
+            post_title="Title",
+            post_url="https://example.com/some/post",
+            excerpt="x" * 500,
+            tags=tags,
+            max_length=100,
+        )
+        # No leading run of the excerpt body survived the clamp.
+        self.assertFalse(content.startswith("x"))
+        self.assertIn("https://example.com/some/post", content)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_split_multi_image_posts.py
+++ b/tests/test_split_multi_image_posts.py
@@ -27,7 +27,6 @@ from unittest.mock import patch, MagicMock
 
 from posse.posse import (
     _has_nosplit_tag,
-    _filter_nosplit_tag,
     _format_post_content,
     NOSPLIT_TAG,
     NOFEATURE_TAG
@@ -301,48 +300,6 @@ class TestNosplitTagDetection(unittest.TestCase):
             {"name": "#photography", "slug": "hash-photography"}
         ]
         self.assertFalse(_has_nosplit_tag(tags))
-
-    def test_filter_nosplit_tag_removes_tag(self):
-        """Test that _filter_nosplit_tag removes #nosplit from tags."""
-        tags = [
-            {"name": "#photography", "slug": "hash-photography"},
-            {"name": "#nosplit", "slug": "hash-nosplit"},
-            {"name": "#posse", "slug": "hash-posse"}
-        ]
-        filtered = _filter_nosplit_tag(tags)
-
-        self.assertEqual(len(filtered), 2)
-        tag_names = [t["name"] for t in filtered]
-        self.assertIn("#photography", tag_names)
-        self.assertIn("#posse", tag_names)
-        self.assertNotIn("#nosplit", tag_names)
-
-    def test_filter_nosplit_tag_case_insensitive(self):
-        """Test that _filter_nosplit_tag is case-insensitive."""
-        tags = [
-            {"name": "#photography", "slug": "hash-photography"},
-            {"name": "#NOSPLIT", "slug": "hash-nosplit"}
-        ]
-        filtered = _filter_nosplit_tag(tags)
-
-        self.assertEqual(len(filtered), 1)
-        self.assertEqual(filtered[0]["name"], "#photography")
-
-    def test_filter_nosplit_tag_preserves_other_tags(self):
-        """Test that _filter_nosplit_tag doesn't affect tags without #nosplit."""
-        tags = [
-            {"name": "#photography", "slug": "hash-photography"},
-            {"name": "#travel", "slug": "hash-travel"}
-        ]
-        filtered = _filter_nosplit_tag(tags)
-
-        self.assertEqual(len(filtered), 2)
-        self.assertEqual(filtered, tags)
-
-    def test_filter_nosplit_tag_empty_list(self):
-        """Test that _filter_nosplit_tag handles empty list."""
-        filtered = _filter_nosplit_tag([])
-        self.assertEqual(filtered, [])
 
 
 class TestServiceTagsInPostContent(unittest.TestCase):

--- a/tests/test_webmention_receiver.py
+++ b/tests/test_webmention_receiver.py
@@ -331,6 +331,27 @@ class TestSourceLinksToTarget:
         html = '<link rel="canonical" href="https://blog.example.com/post">'
         assert _source_links_to_target(html, "https://blog.example.com/post") is True
 
+    def test_ref_query_param_ignored(self):
+        # POSSE appends ?ref=<platform> to its own links; a source echoing that
+        # URL must still verify against the bare target.
+        html = '<a href="https://blog.example.com/post?ref=mastodon">Link</a>'
+        assert _source_links_to_target(html, "https://blog.example.com/post") is True
+
+    def test_scheme_difference_ignored(self):
+        html = '<a href="http://blog.example.com/post">Link</a>'
+        assert _source_links_to_target(html, "https://blog.example.com/post") is True
+
+    def test_href_inside_comment_not_matched(self):
+        # A link present only inside an HTML comment is not a visible mention.
+        html = '<!-- <a href="https://blog.example.com/post">hidden</a> --><p>nope</p>'
+        assert _source_links_to_target(html, "https://blog.example.com/post") is False
+
+    def test_relative_href_resolved_against_source(self):
+        html = '<a href="/post">Link</a>'
+        assert _source_links_to_target(
+            html, "https://blog.example.com/post", base_url="https://blog.example.com/feed"
+        ) is True
+
 
 class TestExtractHentryMetadata:
     def test_basic_hentry(self):
@@ -392,6 +413,7 @@ class TestVerifyWebmention:
         mock_response = MagicMock()
         mock_response.ok = True
         mock_response.status_code = 200
+        mock_response.is_redirect = False
         mock_response.encoding = "utf-8"
         mock_response.iter_content = MagicMock(return_value=[html.encode()])
         mock_response.close = MagicMock()
@@ -401,6 +423,7 @@ class TestVerifyWebmention:
         store.put_received_webmention(source, target, "2024-01-01T00:00:00Z")
 
         with patch("indieweb.receiver._is_private_or_loopback", return_value=False), \
+             patch("indieweb.webmention._is_private_or_loopback", return_value=False), \
              patch("indieweb.receiver._build_session") as mock_session:
             mock_session.return_value.get.return_value = mock_response
             verify_webmention(source, target, store)
@@ -415,6 +438,7 @@ class TestVerifyWebmention:
         mock_response = MagicMock()
         mock_response.ok = True
         mock_response.status_code = 200
+        mock_response.is_redirect = False
         mock_response.encoding = "utf-8"
         mock_response.iter_content = MagicMock(return_value=[html.encode()])
         mock_response.close = MagicMock()
@@ -424,6 +448,7 @@ class TestVerifyWebmention:
         store.put_received_webmention(source, target, "2024-01-01T00:00:00Z")
 
         with patch("indieweb.receiver._is_private_or_loopback", return_value=False), \
+             patch("indieweb.webmention._is_private_or_loopback", return_value=False), \
              patch("indieweb.receiver._build_session") as mock_session:
             mock_session.return_value.get.return_value = mock_response
             verify_webmention(source, target, store)
@@ -436,6 +461,7 @@ class TestVerifyWebmention:
         mock_response = MagicMock()
         mock_response.status_code = 404
         mock_response.ok = False
+        mock_response.is_redirect = False
         mock_response.close = MagicMock()
 
         source = "https://source.example.com/post"
@@ -443,6 +469,7 @@ class TestVerifyWebmention:
         store.put_received_webmention(source, target, "2024-01-01T00:00:00Z")
 
         with patch("indieweb.receiver._is_private_or_loopback", return_value=False), \
+             patch("indieweb.webmention._is_private_or_loopback", return_value=False), \
              patch("indieweb.receiver._build_session") as mock_session:
             mock_session.return_value.get.return_value = mock_response
             verify_webmention(source, target, store)
@@ -456,6 +483,7 @@ class TestVerifyWebmention:
         mock_response = MagicMock()
         mock_response.status_code = 410
         mock_response.ok = False
+        mock_response.is_redirect = False
         mock_response.close = MagicMock()
 
         source = "https://source.example.com/post"
@@ -463,6 +491,7 @@ class TestVerifyWebmention:
         store.put_received_webmention(source, target, "2024-01-01T00:00:00Z")
 
         with patch("indieweb.receiver._is_private_or_loopback", return_value=False), \
+             patch("indieweb.webmention._is_private_or_loopback", return_value=False), \
              patch("indieweb.receiver._build_session") as mock_session:
             mock_session.return_value.get.return_value = mock_response
             verify_webmention(source, target, store)


### PR DESCRIPTION
## Summary

A batch of bug fixes from a high-effort review of the whole tree. Each addresses a concrete failure path; the larger duplication refactors the review also flagged are intentionally out of scope.

### Correctness & security
- **SSRF via redirect** — added `_checked_get`, which follows redirects manually and re-runs the private/loopback guard on every hop. The receiver source fetch and endpoint discovery use it; webmention POSTs no longer auto-follow redirects.
- **Concurrent row races** — added a per-database reentrant lock (`store.transaction()`) and wrapped every interaction/mapping read-modify-write (`store_syndication_mapping`, `update_interaction_data_on_syndication`, dead-link suppress/restore, sweep phase-2). Periodic sync re-reads under the lock before its final write and drops accounts suppressed mid-sync so a dead link isn't resurrected.
- **`as_completed` timeout** — a slow account hitting the 120s wait no longer skips image cleanup, webmention sending, and `task_done()`.
- **Pushover recursion** — per-thread re-entrancy guard in `emit()` stops the infinite loop when the API is down and the failure log routes back into the handler.
- **Bluesky faceting** — keep a balanced trailing `)` on URLs (Wikipedia-style links), and skip facets that overlap an already-emitted one (a `#fragment` inside a URL no longer duplicates text / corrupts byte offsets).
- **Bluesky retry** — only retry 429/503, not ambiguous 500/502/504, since `send_post` isn't idempotent and a post-commit 5xx would duplicate the post.
- **Webmention verification** — parse real `<a>/<link>` anchors (ignoring comments/scripts) and normalize scheme, trailing slash, and `?ref=`, fixing false rejections and comment-based false positives.
- **Replies / sync** — filter Mastodon direct replies before taking the latest 10; seed newly-(re)populated accounts silently instead of re-notifying every old reply; throttle older posts by cycle count instead of wall-clock hour parity.
- **`max_text_length` clamp** — clamp to ≥0 and harden `trim_to_words` so long hashtags+URL can't produce over-length posts via a negative slice.

### Efficiency & cleanup
- Dropped unused Mastodon `status_favourited_by`/`status_reblogged_by` and redundant Bluesky `get_likes`/`get_reposted_by` calls (counts come from the status/thread objects; also fixes the silent cap at 100).
- Removed dead code: `_prepare_content`, `_filter_nosplit_tag` (and its tests), and an unused `import re`.

### Not included
- The **repost split-mapping** finding turned out benign (reposting a dead split as a single live post is intended, and sync handles both shapes), so no change.
- **DNS-rebinding TOCTOU** — the redirect fix closes the main SSRF vector; full IP-pinning would break HTTPS SNI/cert validation, so it's left for a dedicated follow-up.

## Test plan
- Added regression tests for the Bluesky facet fixes, verification normalization, the `max_text_length` clamp, and the Pushover recursion guard; updated the Bluesky retry tests for the new 5xx behavior.
- `docker compose --profile test run --rm test` — **594 passed, 8 subtests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)