### PR TITLE
Suppress GHSA-537c-gmf6-5ccf (cryptography) — no installable fix due to atproto cap

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,12 +6,16 @@ on:
       - poetry.lock
       - pyproject.toml
       - Dockerfile
+      - .trivyignore
+      - osv-scanner.toml
   push:
     branches: [ main ]
     paths:
       - poetry.lock
       - pyproject.toml
       - Dockerfile
+      - .trivyignore
+      - osv-scanner.toml
   # Weekly scan catches advisories published against versions we already
   # run, independent of any dependency change landing.
   schedule:

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,18 @@
+# Trivy ignore file — consumed by the image-scan job in .github/workflows/audit.yml.
+#
+# GHSA-537c-gmf6-5ccf — "Vulnerable OpenSSL included in cryptography wheels"
+#
+# cryptography is not a first-party dependency: POSSE's own code never imports
+# it. It is pulled in transitively by atproto, whose every published release
+# (up to and including the latest, 0.0.68) constrains `cryptography <47`.
+# The advisory is only fixed in cryptography 48.0.1, so there is no version
+# that satisfies both atproto's ceiling and the fix — `poetry lock` fails to
+# resolve if we floor cryptography at >=48.0.1.
+#
+# The flaw lives in the OpenSSL statically bundled in cryptography's prebuilt
+# wheels, not in cryptography's own Python code. We accept this finding until
+# atproto relaxes its <47 pin (track https://github.com/MarshalX/atproto), at
+# which point cryptography should be floored at >=48.0.1 and this entry removed.
+#
+# Review by: 2026-09-01
+GHSA-537c-gmf6-5ccf

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,15 @@
+# OSV-Scanner config — consumed by the osv-scan job in .github/workflows/audit.yml.
+# https://google.github.io/osv-scanner/configuration/
+
+# GHSA-537c-gmf6-5ccf — "Vulnerable OpenSSL included in cryptography wheels".
+#
+# cryptography is only present transitively via atproto, whose every published
+# release (through the latest, 0.0.68) pins `cryptography <47`. The advisory is
+# only fixed in 48.0.1, so no version satisfies both atproto's ceiling and the
+# fix. The flaw is in the OpenSSL bundled in cryptography's prebuilt wheels, not
+# in its Python code. Revisit once atproto relaxes the <47 pin, then floor
+# cryptography at >=48.0.1 and remove this entry.
+[[IgnoredVulns]]
+id = "GHSA-537c-gmf6-5ccf"
+ignoreUntil = 2026-09-01
+reason = "Transitive via atproto, which pins cryptography <47; fix is 48.0.1 (unsatisfiable). Bundled-OpenSSL wheel issue only."


### PR DESCRIPTION
## Summary

The Dependency Audit workflow (`audit.yml`) failed on **GHSA-537c-gmf6-5ccf** — *"Vulnerable OpenSSL included in cryptography wheels"* (HIGH) — flagged against `cryptography 46.0.7`.

This **cannot be fixed by a version bump**:

- `cryptography` is **not** a first-party dependency — POSSE's own code never imports it. It is pulled in transitively by **`atproto`**.
- `atproto` pins `cryptography <47` in **every published release**, including the latest (`0.0.68`). (The `cryptography = ">=46.0.7"` line in `pyproject.toml` was only ever a floor to clear *older* CVEs; 46.0.7 is the highest `atproto` allows.)
- The advisory is fixed **only in `cryptography 48.0.1`** (confirmed via OSV: a single range `introduced 0.5.0 → fixed 48.0.1`, no 46.x/47.x backport).
- So no version satisfies both `atproto`'s ceiling and the fix — `poetry lock` with a `>=48.0.1` floor fails to resolve (verified locally).

The flaw lives in the OpenSSL **statically bundled in cryptography's prebuilt wheels**, not in cryptography's Python code.

## Changes

- **`.trivyignore`** — documented, dated ignore for the Trivy image scan.
- **`osv-scanner.toml`** — matching `IgnoredVulns` entry (with `ignoreUntil = 2026-09-01`) for the OSV lockfile scan, which would otherwise flag the same advisory.
- **`audit.yml`** — added `.trivyignore` and `osv-scanner.toml` to the `pull_request`/`push` path filters so the audit gate re-runs when these suppressions change.

Both files carry the same justification and a **2026-09-01 review date**: revisit once `atproto` relaxes its `<47` pin, then floor `cryptography` at `>=48.0.1` and remove the entries. `pyproject.toml` and `poetry.lock` are intentionally unchanged.

## Test plan

Verified locally with the same scanner versions the CI uses:

- **OSV-Scanner** on `poetry.lock`: `GHSA-537c-gmf6-5ccf has been filtered out ... Filtered 1 vulnerability` → **No issues found**, exit 0.
- **Trivy v0.70.0** (`HIGH,CRITICAL`, `--ignore-unfixed`):
  - without the ignore file → `Total: 1 (HIGH: 1)`, exit 1 (reproduces the CI failure)
  - with `.trivyignore` → `0` findings, *"Some vulnerabilities have been ignored/suppressed"*, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UngPQhUWvuvddmGkktJK75)_